### PR TITLE
fix: save the converged embedding in ProgressiveCrammingTrainer (off-…

### DIFF
--- a/src/compression_horizon/train/trainers/progressive_cramming.py
+++ b/src/compression_horizon/train/trainers/progressive_cramming.py
@@ -899,6 +899,20 @@ class ProgressiveCrammingTrainer(BaseTrainer):
                 target_hidden_states=stage_ctx.target_hidden_states,
                 prefix_len=batch_ctx.prefix_len,
             )
+            last_loss = float(loss.item())
+            last_convergence = convergence_per_sample.detach().cpu()
+
+            # Plan B (measure-then-decide): decide convergence on the CURRENT (live,
+            # just-forwarded) embedding *before* stepping. ``state.update`` marks any
+            # newly-converged sample inactive, so ``_step_per_sample_optimizers`` below
+            # skips it and its live embedding stays exactly the one we just measured.
+            # This keeps the embedding saved by ``_collect_stage_rows`` consistent with
+            # the recorded ``final_convergence``/``final_loss`` -- previously the optimizer
+            # took one extra step after the converged forward, so the saved embedding was
+            # one optimizer step past the metrics recorded for it.
+            if state.update(convergence_per_sample):
+                return last_loss, last_convergence, True
+
             loss.backward()
 
             self._log_progress(
@@ -916,20 +930,53 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             self._step_per_sample_optimizers(batch_ctx, state)
             self._step_shared_optimizer(batch_ctx)
 
-            last_loss = float(loss.item())
-            last_convergence = convergence_per_sample.detach().cpu()
-
-            if state.update(convergence_per_sample):
-                return last_loss, last_convergence, True
-
             # Hard cap on cumulative per-sample steps across stages within this batch.
             # An exhausted sample is permanently skipped; if that drains the batch,
             # exit the stage as "converged" so the outer retry path doesn't fire
-            # (a budget-exhausted sample can't make progress on retry).
+            # (a budget-exhausted sample can't make progress on retry). The optimizer
+            # just stepped, so re-measure the live embedding to keep the returned metrics
+            # consistent with the embedding ``_collect_stage_rows`` will save.
             if state.mark_exhausted(self.args.max_optimization_steps_per_sample):
+                last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx)
                 return last_loss, last_convergence, True
 
+        # Max steps for this stage reached without all samples converging. The optimizer
+        # stepped on the final iteration, so re-measure the live (post-step) embedding to
+        # keep the returned metrics consistent with what ``_collect_stage_rows`` saves.
+        last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx)
         return last_loss, last_convergence, False
+
+    @torch.no_grad()
+    def _measure_live(self, batch_ctx: "_BatchContext", stage_ctx: "_StageContext", ctx: "_RunContext"):
+        """Forward the current live embedding; return ``(loss, convergence_per_sample_cpu)``.
+
+        Used only on non-converged stage exits (per-sample budget exhausted, or max steps
+        reached) where the optimizer has stepped past the last measured embedding. Re-measuring
+        the live embedding keeps the recorded ``final_loss``/``final_convergence`` consistent
+        with the post-step embedding that ``_collect_stage_rows`` materializes. Converged exits
+        return before stepping, so they need no re-measure.
+        """
+        compression_token_embeddings = batch_ctx.parametrization.materialize().clone()
+        united_token_embeddings, united_attention_mask = build_united_input(
+            compression_token_embeddings,
+            batch_ctx.compression_attention_mask,
+            stage_ctx.inputs_embeds,
+            stage_ctx.attention_mask,
+            prefix_token_embeddings=batch_ctx.prefix_token_embeddings,
+            prefix_attention_mask=batch_ctx.prefix_attention_mask,
+        )
+        loss, _alignment_loss, convergence_per_sample, _generated_text, _ground_truth_text = self.forward_and_compute_loss(
+            ctx.decode_model,
+            stage_ctx.input_ids,
+            stage_ctx.inputs_embeds,
+            stage_ctx.attention_mask,
+            united_token_embeddings,
+            united_attention_mask,
+            ctx.num_compression_tokens,
+            target_hidden_states=stage_ctx.target_hidden_states,
+            prefix_len=batch_ctx.prefix_len,
+        )
+        return float(loss.item()), convergence_per_sample.detach().cpu()
 
     def _step_per_sample_optimizers(self, batch_ctx: _BatchContext, state: ProgressiveSampleStateMachine) -> None:
         """Step active samples' optimizers; zero grads for all (active + skipped + already-converged-in-stage)."""

--- a/tests/test_progressive_cramming_trainer.py
+++ b/tests/test_progressive_cramming_trainer.py
@@ -146,3 +146,70 @@ def test_geometric_search_finds_horizon_and_restores_on_backoff(horizon, backoff
         assert len(restore_calls) == (1 if fail_idxs else 0), f"linear should restore once, got {len(restore_calls)}"
         walk = all_lens[fail_idxs[0] + 1 :] if fail_idxs else []
         assert all(b - a == 1 for a, b in zip(walk, walk[1:])), f"linear walk not +1 contiguous: {walk}"
+
+
+def test_run_steps_does_not_step_after_convergence():
+    """Plan B regression (off-by-one save bug): the optimizer must NOT step on the iteration
+    where convergence is detected, so the live embedding ``_collect_stage_rows`` saves is exactly
+    the one whose convergence/loss were recorded.
+
+    Convergence is forced to cross the threshold on iteration ``K``. The fix forwards ``K+1``
+    times (iters 0..K) but steps only ``K`` times (iters 0..K-1). The old code stepped before the
+    convergence check, so it would step ``K+1`` times -- one wasted step past the saved metrics.
+    CPU-only, fully deterministic.
+    """
+    args = _make_args(progressive_train=True, max_optimization_steps_per_sample=10**9)
+    trainer = _blank_trainer(args)
+
+    K = 4
+    calls = {"forward": 0, "steps": 0}
+    param = torch.nn.Parameter(torch.zeros(1, 1, 4))  # real leaf so loss.backward() works
+
+    fake_param = SimpleNamespace(parameters=[param], shared_parameters=[], materialize=lambda: param)
+    batch_ctx = SimpleNamespace(
+        batch_size=1,
+        parametrization=fake_param,
+        compression_attention_mask=torch.ones(1, 1, dtype=torch.long),
+        prefix_token_embeddings=None,
+        prefix_attention_mask=None,
+        prefix_len=0,
+        per_sample_optimizers=[None],
+        per_sample_schedulers=[None],
+        shared_optimizer=None,
+        shared_scheduler=None,
+    )
+    stage_ctx = SimpleNamespace(
+        seq_len=2,
+        stage_index=0,
+        input_ids=torch.zeros(1, 2, dtype=torch.long),
+        inputs_embeds=torch.zeros(1, 2, 4),
+        attention_mask=torch.ones(1, 2, dtype=torch.long),
+        target_hidden_states=None,
+    )
+    ctx = SimpleNamespace(decode_model=None, num_compression_tokens=1)
+
+    def fake_forward(*_a, **_k):
+        i = calls["forward"]
+        calls["forward"] += 1
+        conv = torch.tensor([1.0 if i >= K else 0.0])
+        loss = (param**2).sum()  # real graph so the non-converged iters can .backward()
+        return loss, None, conv, None, None
+
+    def fake_step(_bc, state):
+        calls["steps"] += 1
+        state.increment_steps(0)
+        param.grad = None
+
+    trainer.forward_and_compute_loss = fake_forward
+    trainer._log_progress = lambda **_k: None
+    trainer._step_per_sample_optimizers = fake_step
+    trainer._step_shared_optimizer = lambda _bc: None
+
+    state = ProgressiveSampleStateMachine(1, threshold=1.0)
+    last_loss, last_conv, converged = trainer._run_steps(batch_ctx, stage_ctx, ctx, state, retry=False, max_steps=100)
+
+    assert converged is True
+    assert calls["forward"] == K + 1, f"expected {K + 1} forwards, got {calls['forward']}"
+    assert calls["steps"] == K, f"optimizer stepped {calls['steps']} times, expected {K} (no step on converged iter)"
+    assert state.steps_taken[0] == K, "wasted optimizer step counted after convergence"
+    assert last_conv is not None and float(last_conv[0].item()) >= 1.0


### PR DESCRIPTION
…by-one)

`_run_steps` stepped the per-sample optimizer *before* checking convergence, so on the converging iteration the live embedding advanced one optimizer step past the embedding whose convergence/loss were recorded. `_collect_stage_rows` then saved that post-step embedding (and its information_gain) alongside the pre-step metrics, so the saved trajectory embedding did not reproduce the recorded `final_convergence` (genuine large-margin errors, e.g. a "converged" stage recomputing to 0.83).

Plan B (measure-then-decide): decide convergence on the current (live, just-forwarded) embedding before stepping. `state.update` marks newly-converged samples inactive so the optimizer step skips them and their live embedding stays exactly the measured one. The two non-converged exits (per-sample budget exhausted / max steps) re-measure the post-step live embedding via a new `_measure_live` helper so recorded metrics stay consistent with the saved embedding.

Adds `test_run_steps_does_not_step_after_convergence` (deterministic, CPU): asserts the optimizer steps K times, not K+1, when convergence is reached on iteration K. Verified on a fresh SmolLM2-135M / seq-256 run: every saved stage reproduces its recorded convergence up to bf16 argmax ties; zero genuine displacements.