### PR TITLE
feat: information-gain budget-rebalancing loss (cap + dual) for progr…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,3 +37,25 @@ The published reproducibility repository (FusionBrainLab/progressive_cramming). 
 the renamed `progressive_cramming` package, README, LICENSE, and the existing
 presentation deck. Distinct from the internal `compression_horizon` research repo.
 _Avoid:_ "compression_horizon" when referring to the public artifact.
+
+## Convergence Margin (ε)
+The logit gap a token must clear to count as converged: a position matches only when
+`logit[true] − max_{j≠true} logit[j] ≥ ε`. ε = 0 is legacy bare-argmax convergence; ε > 0
+yields decode-robust reconstruction (survives kernel / forward-shape perturbations) at the
+cost of fewer crammed tokens. The knob of the robustness-versus-compression trade-off.
+_Avoid:_ "confidence threshold", "loss margin" (that names the CE-reweighting knob, not the
+convergence criterion).
+
+## Information-Gain Budget
+The total bits a memory embedding saves on its span, `Σ_token Δsurprisal`, treated as a
+roughly fixed per-model resource that is distributed across the crammed tokens. The premise
+that standard cramming spends this budget unevenly (huge margins on easy tokens, near-zero on
+others) motivates rebalancing it.
+_Avoid:_ "capacity" (broader), "compression budget".
+
+## Budget-Rebalancing Loss
+A training objective that redistributes the Information-Gain Budget across tokens — reclaiming
+budget from over-margined (easy) tokens — so that a larger number of tokens clear the
+Convergence Margin, extending the crammable span at fixed budget. Distinct from the existing
+margin-deficit CE reweighting (+LM), which only raises the floor and never reclaims over-margin.
+_Avoid:_ "margin-weighted loss" / "+LM" (that is the floor-raising baseline, not a rebalancer).

--- a/docs/adr/0004-budget-rebalancing-loss.md
+++ b/docs/adr/0004-budget-rebalancing-loss.md
@@ -1,0 +1,43 @@
+# 4. Budget-rebalancing losses (C: surprisal-cap, D: dual water-filling)
+
+Date: 2026-07-03
+
+## Status
+Accepted
+
+## Context
+Progressive cramming converges each stage to a per-token logit margin (the
+[[Convergence Margin (ε)]] criterion). A model's total [[Information-Gain Budget]]
+(`Σ_token Δsurprisal`) is roughly constant, yet plain cross-entropy spends it unevenly:
+easy tokens acquire huge margins (over-served) while others sit near zero. The branch already
+ships `loss_margin` (the "+LM" margin-deficit reweighting), whose docstring claims "more
+crammed tokens" — but +LM only **raises the floor** (up-weights deficient tokens, zeroes
+easy ones) and **never reclaims** the budget hogged by over-margined tokens. So a naive "new
+loss" risks re-describing +LM.
+
+## Decision
+Introduce a distinct family of [[Budget-Rebalancing Loss]] objectives that actively
+**reclaim** budget from over-margined tokens so more tokens clear ε at a **fixed** ε:
+
+- **C — surprisal-budget cap.** Cap each token's bits-saved at a shared, **adaptive**
+  water-level `c = B / L` (B = per-sample IG budget, L = current span length), penalizing
+  `(Δbits_i − c)₊`. This is the +LM floor-raiser **plus** a reclaim term +LM lacks.
+- **D — dual water-filling.** Maximize a soft count of tokens ≥ ε subject to `Σ Δbits_i ≤ B`,
+  enforced by a dual variable λ (dual ascent); KKT optimum ⇒ water-filling; C is its
+  fixed-level special case.
+
+The water-level/budget is **adaptive from the measured IG** (no hyperparameter sweep). The
+convergence criterion stays margin-ε; the reclaim term is floored so it never pulls a token
+below ε.
+
+## Consequences
+- The loss is genuinely distinct from +LM: reclaim, not just floor-raising. The comparison
+  arms are CE, +LM, C, D at matched ε — success = C/D cram **more tokens at fixed ε**.
+- Adaptive water-level adds **zero** sweep runs and directly operationalizes the fixed-budget
+  premise; if the premise is wrong (budget not fungible), the pre-registered null still holds
+  (a finding, not a failure).
+- Two objectives (fixed-level C and learned-level D) probe the same water-filling idea at
+  different complexity; D's dual update lives in the inner cramming loop.
+- Hard to reverse once runs, tables, and appendix text are built around C/D as the canonical
+  rebalancers; the alternatives (two-sided margin, raise-the-floor soft-min) are deferred, not
+  deleted.

--- a/docs/adr/0005-cap-on-true-bits-saved-cached-h-base.md
+++ b/docs/adr/0005-cap-on-true-bits-saved-cached-h-base.md
@@ -1,0 +1,40 @@
+# 5. Rebalance on true bits-saved, with a cached per-stage H_base
+
+Date: 2026-07-03
+
+## Status
+Accepted
+
+## Context
+The [[Budget-Rebalancing Loss]] must cap "how much budget a token consumes." Two candidate
+quantities:
+
+- **Per-token margin** `m_i = logit[true] − runnerup` — falls out of the logits already
+  computed, so it is **free**, and is monotone in bits-saved near the decision boundary.
+- **Per-token bits-saved** `Δbits_i = (H_base,i − CE_i)/ln2` — faithful to the
+  [[Information-Gain Budget]] (`H_base` = frozen-LM surprisal without the memory embedding),
+  but naively needs an extra `H_base` forward **every** optimization step (≈2× forward cost
+  over up to 10k steps/sample).
+
+The margin proxy is cheaper; bits-saved is the actual quantity the "IG budget" story is about.
+
+## Decision
+Rebalance on **true per-token bits-saved**, not the margin proxy. Exploit that **`H_base` is
+independent of the memory embedding being optimized** (it is the frozen LM on the plain
+prefix+continuation): compute per-token `H_base` **once per stage and cache it**. Per step,
+only `H_comp,i = CE_i` changes — and that is already computed by the loss — so
+`Δbits_i = (H_base,i − CE_i)/ln2` is available with **no extra per-step forward**. Reuse the
+base-forward logic in `analysis/information_gain.py` (Eq. 9) for both the cache and the
+offline IG-conservation check.
+
+## Consequences
+- Faithfulness without the feared 2× cost: the extra cost collapses to **one** frozen-LM
+  forward per stage, not per step.
+- Correctness dependency: the cache must be **invalidated when the span grows** (each new
+  progressive stage recomputes `H_base` for the extended continuation) and be prefix-aware
+  (`H_lm(cont | prefix)`); a stale cache silently corrupts every `Δbits_i`.
+- Ties the loss directly to the paper's IG definition, so the IG-conservation acceptance
+  criterion (`Σ Δbits` under C/D ≈ baseline) is a first-class check.
+- Trade-off: rejects the essentially-free margin proxy; if bits-saved and margin turn out to
+  rank tokens near-identically, the extra machinery buys little — an escalation/​fallback to
+  the margin proxy remains open but is not the chosen path.

--- a/experiments/budget_rebalancing.md
+++ b/experiments/budget_rebalancing.md
@@ -1,0 +1,53 @@
+# Information-Gain Budget Rebalancing
+
+## Hypothesis
+
+A model's information-gain budget (`Σ_token Δsurprisal`) is roughly constant, but plain
+cross-entropy cramming spends it unevenly — over-margined easy tokens hog budget while others sit
+at near-zero margin. A **budget-rebalancing loss** that reclaims budget from over-margined tokens
+should let **more tokens clear a fixed convergence margin ε** (a longer crammed span) than plain-CE
+or the existing margin-deficit reweighting (+LM), which only raises the floor and never reclaims.
+Pre-registered null: if the budget is **not** fungible across tokens (through the single shared
+embedding), the token count stays flat while the margin distribution still flattens — evidence that
+the budget is not redistributable, which is itself a finding.
+
+## Setup
+
+- **Training function**: `ProgressiveCrammingTrainer` (`src/compression_horizon/train/trainers/progressive_cramming.py`)
+- **Loss**: `budget_rebalance_loss_with_prefix` (`src/compression_horizon/train/loss.py`), two arms
+  - `cap` (C): margin-deficit CE floor + a reclaim term pulling over-budget tokens down to an
+    adaptive water level `c = B/L` (B = per-sample IG at stage start, cached `H_base`).
+  - `dual` (D): maximize a soft count of tokens past ε subject to `Σ Δbits ≤ B` via a per-sample
+    dual variable (dual ascent). KKT optimum is water-filling.
+- **Baselines (already run)**: plain-CE (`convergence_margin=ε`) and +LM (`loss_margin=ε`).
+- **Model / dataset / grid**: Pythia-1.4B deep dive (baseline + low-dim 256), ε ∈ {0.5, 1.0, 2.0},
+  PG19, 50 samples. Full matrix lives in `scripts/jobs/run_jobs_progressive.py`
+  (`BUDGET_REBALANCE_EXPERIMENTS`, 12 new runs). **Source is the single source of truth.**
+- **Metric**: crammed-token count at fixed ε (C/D vs CE/+LM). Diagnostics (fungibility probe):
+  per-token margin variance, min-margin, Δbits inequality — logged under `budget/*` in TensorBoard.
+
+## Training
+
+```bash
+PYTHONPATH=./src python scripts/jobs/run_jobs_progressive.py --dry
+```
+
+## Expected outcome
+
+At each ε, `cap`/`dual` converge a **longer span** (more crammed tokens) than plain-CE and +LM at
+matched ε, with the IG budget conserved (`Σ Δbits` ≈ baseline) and a flatter per-token margin
+distribution. A flat token count with flattened margins would support the non-fungible-budget null.
+
+## Results
+
+_To be filled after running the experiment._
+
+## Conclusions
+
+_To be filled after analysis._
+
+## Changelog
+
+- 2026-07-03: Plan created; `cap`/`dual` losses + cached `H_base` + 12 Pythia arms implemented and
+  unit/integration-tested. Runs not yet launched. Design + rationale: deep-interview spec
+  (`run/deep-interview/deep-interview-budget-rebalancing-loss.md`) and ADRs 0004/0005.

--- a/scripts/jobs/run_jobs_progressive.py
+++ b/scripts/jobs/run_jobs_progressive.py
@@ -240,6 +240,37 @@ MARGIN_EXPERIMENTS = [
     for with_loss_margin in (False, True)
 ]
 
+# --- Information-gain budget rebalancing (Pythia-1.4B deep dive) ------------------------
+# Single-model deep dive: does a budget-rebalancing loss fit MORE tokens at a FIXED convergence
+# margin epsilon than plain-CE / +LM? Both new arms redistribute the (roughly constant) IG budget
+# by reclaiming bits from over-margined tokens: 'cap' (C) adds a reclaim term on top of the +LM
+# floor; 'dual' (D) water-fills under a total-bits budget via a per-sample dual variable. Baselines
+# at the same epsilon are the existing Pythia MARGIN_EXPERIMENTS rows (plain-CE = _cm_, +LM = _lm_).
+# 2 base (baseline + low-dim 256) x len(CONVERGENCE_MARGINS) x 2 modes = 12 runs for eps in {0.5,1.0,2.0}.
+BUDGET_REBALANCE_BASE = [
+    ("EleutherAI/pythia-1.4b", 0.5, None),
+    ("EleutherAI/pythia-1.4b", 0.5, 256),
+]
+BUDGET_REBALANCE_MODES = ["cap", "dual"]
+
+BUDGET_REBALANCE_EXPERIMENTS = [
+    {
+        "model_checkpoint": model_checkpoint,
+        "learning_rate": learning_rate,
+        "loss_type": "cross_entropy",
+        "num_alignment_layers": 1,
+        "hybrid_alpha": None,
+        "low_dim_projection": low_dim_size is not None,
+        "low_dim_size": low_dim_size,
+        # convergence_margin is epsilon (the fixed bar); the rebalancing loss reads it as its target.
+        "convergence_margin": convergence_margin,
+        "budget_rebalance_mode": mode,
+    }
+    for (model_checkpoint, learning_rate, low_dim_size) in BUDGET_REBALANCE_BASE
+    for convergence_margin in CONVERGENCE_MARGINS
+    for mode in BUDGET_REBALANCE_MODES
+]
+
 EXPERIMENTS = [
     *LLAMA_31_8B_EXPERIMENTS,
     *PYTHIA_14B_EXPERIMENTS,
@@ -247,6 +278,7 @@ EXPERIMENTS = [
     *GEMMA_3_4B_EXPERIMENTS,
     *QWEN3_EXPERIMENTS,
     *MARGIN_EXPERIMENTS,
+    *BUDGET_REBALANCE_EXPERIMENTS,
 ]
 
 
@@ -326,6 +358,18 @@ def render_job(experiment):
     if loss_margin is not None:
         cmd_args.append(f"--loss_margin {loss_margin}")
         exp_suffix = f"{exp_suffix}_lm_{loss_margin}"
+
+    # Information-gain budget rebalancing (Pythia deep dive). ``.get`` keeps every existing
+    # experiment byte-identical (no key => no flag, no suffix). 'cap'/'dual' redistribute the IG
+    # budget so more tokens clear the convergence_margin above; see train/{arguments,loss}.py.
+    budget_rebalance_mode = experiment.get("budget_rebalance_mode")
+    if budget_rebalance_mode and budget_rebalance_mode != "none":
+        cmd_args.append(f"--budget_rebalance_mode {budget_rebalance_mode}")
+        exp_suffix = f"{exp_suffix}_brl_{budget_rebalance_mode}"
+        budget_rebalance_weight = experiment.get("budget_rebalance_weight")
+        if budget_rebalance_weight is not None:
+            cmd_args.append(f"--budget_rebalance_weight {budget_rebalance_weight}")
+            exp_suffix = f"{exp_suffix}_w_{budget_rebalance_weight}"
 
     # Fixed uncompressed prefix (progressive cramming). ``.get`` keeps every existing experiment
     # byte-identical (no key => no flag, no suffix); set it to enable the prefix-length ablation.

--- a/src/compression_horizon/analysis/information_gain.py
+++ b/src/compression_horizon/analysis/information_gain.py
@@ -141,3 +141,62 @@ def compute_prefix_surprisal_bits_per_token(
         total_bits = _sequence_cross_entropy_bits(outputs.logits, sample_ids, sample_mask, align_offset=0)
         bits_per_token.append(total_bits / scored)
     return bits_per_token
+
+
+@torch.no_grad()
+def compute_per_token_base_surprisal_nats(
+    *,
+    model: nn.Module,
+    input_ids: torch.Tensor,  # [batch, sequence] -- the continuation (loss target)
+    attention_mask: torch.Tensor,  # [batch, sequence]
+    prefix_token_embeddings: torch.Tensor | None = None,  # [batch, prefix, hidden]
+    prefix_attention_mask: torch.Tensor | None = None,  # [batch, prefix]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token base-LM next-token surprisal (nats) for each continuation token, WITHOUT the mem token.
+
+    Returns ``(base_ce_nats, valid_mask)`` both ``[batch, sequence]`` and aligned 1:1 with the
+    continuation ``input_ids`` (position ``i`` holds the frozen LM's ``-log p(x_i | context)``).
+    This is ``H_base`` in the information-gain decomposition; it is **independent of the memory
+    embedding being optimized**, so a caller caches it once per progressive stage and reuses it
+    every optimization step to form ``delta_bits_i = (H_base_i - H_comp_i)/ln2`` for the
+    budget-rebalancing loss.
+
+    With a real prefix the model attends to it, so token 0 has context and every position is valid.
+    Without a prefix, token 0 has no predictor (nothing precedes it) — its entry is 0.0 and marked
+    invalid, matching how ``compute_information_gain`` scores only the well-defined continuation.
+    Padding positions (``attention_mask == 0``) are also marked invalid.
+    """
+    batch_size, seq_len = input_ids.shape
+    device = input_ids.device
+    base_ce = torch.zeros((batch_size, seq_len), dtype=torch.float32, device=device)
+    valid = attention_mask == 1
+
+    if prefix_token_embeddings is not None and prefix_token_embeddings.size(1) > 0:
+        prefix_len = prefix_token_embeddings.size(1)
+        cont_embeddings = model.get_input_embeddings()(input_ids).to(prefix_token_embeddings.dtype)
+        embeddings = torch.cat((prefix_token_embeddings, cont_embeddings), dim=1)
+        mask = torch.cat((prefix_attention_mask, attention_mask), dim=1)
+        logits = model(inputs_embeds=embeddings, attention_mask=mask).logits
+        # Positions prefix_len-1 .. prefix_len-1+L-1 predict continuation tokens 0 .. L-1.
+        pred_logits = logits[:, prefix_len - 1 : prefix_len - 1 + seq_len, :]
+        base_ce = F.cross_entropy(
+            pred_logits.reshape(-1, pred_logits.size(-1)).float(),
+            input_ids.reshape(-1),
+            reduction="none",
+        ).view(batch_size, seq_len)
+    else:
+        logits = model(input_ids=input_ids, attention_mask=attention_mask).logits
+        # Position i predicts token i+1; token 0 has no predictor -> stays 0.0 / invalid.
+        if seq_len > 1:
+            pred_logits = logits[:, :-1, :]  # predicts tokens 1 .. L-1
+            ce_shifted = F.cross_entropy(
+                pred_logits.reshape(-1, pred_logits.size(-1)).float(),
+                input_ids[:, 1:].reshape(-1),
+                reduction="none",
+            ).view(batch_size, seq_len - 1)
+            base_ce[:, 1:] = ce_shifted
+        valid = valid.clone()
+        valid[:, 0] = False
+
+    base_ce = base_ce.masked_fill(~valid, 0.0)
+    return base_ce, valid

--- a/src/compression_horizon/train/arguments.py
+++ b/src/compression_horizon/train/arguments.py
@@ -387,6 +387,52 @@ class MyTrainingArguments(TrainingArguments):
         },
     )
 
+    # --- Information-gain budget rebalancing ----------------------------
+    budget_rebalance_mode: str = field(
+        default="none",
+        metadata={
+            "help": (
+                "Redistribute the (roughly constant) information-gain budget across tokens so more of "
+                "them clear the convergence margin at fixed epsilon. 'none' = disabled (plain CE / +LM). "
+                "'cap' (C) = margin-deficit CE floor (push deficient tokens to epsilon) PLUS a reclaim "
+                "term that pulls over-margined tokens' bits-saved down to an adaptive per-token water "
+                "level c = B/L (B = per-sample IG budget measured at stage start, L = scored tokens). "
+                "'dual' (D) = maximize a soft count of tokens past epsilon subject to a total-bits budget "
+                "Sum_i delta_bits_i <= B via a per-sample dual variable (dual ascent). Both act on true "
+                "bits-saved delta_bits_i = (H_base_i - H_comp_i)/ln2 with H_base cached per stage. Uses "
+                "convergence_margin as epsilon."
+            )
+        },
+    )
+    budget_rebalance_weight: float = field(
+        default=1.0,
+        metadata={
+            "help": (
+                "Weight of the reclaim term (cap mode) applied on top of the margin-deficit CE floor. "
+                "Larger => harder reclaim of over-budget tokens. Ignored when budget_rebalance_mode='none'."
+            )
+        },
+    )
+    budget_rebalance_dual_lr: float = field(
+        default=0.05,
+        metadata={
+            "help": (
+                "Dual-ascent step size for the per-sample Lagrange multiplier lambda that enforces the "
+                "total-bits budget in 'dual' mode: lambda <- relu(lambda + dual_lr * (bits - B)). "
+                "Only used when budget_rebalance_mode='dual'."
+            )
+        },
+    )
+    budget_rebalance_softcount_tau: float = field(
+        default=0.5,
+        metadata={
+            "help": (
+                "Temperature of the sigmoid soft count sigmoid((margin - epsilon)/tau) that D maximizes. "
+                "Smaller => sharper (closer to a hard count of tokens past epsilon). 'dual' mode only."
+            )
+        },
+    )
+
     # --- Precision ------------------------------------------------------
     dtype: str = field(
         default="bf16",

--- a/src/compression_horizon/train/loss.py
+++ b/src/compression_horizon/train/loss.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.nn.functional as F
+
+_LN2 = math.log(2.0)
 
 
 def get_alignment_layer_indices(total_layers: int, num_alignment_layers: int, inverted_alignment: bool) -> range:
@@ -323,3 +327,127 @@ def token_argmax_match_rate(
     matches = ((prediction_ids == input_ids[:, 1:]) & (attention_mask[:, 1:] == 1)).sum(dim=-1)
     ratio = matches / attention_mask[:, 1:].sum(dim=-1).clamp_min(1)
     return ratio
+
+
+def _per_token_margin(pred_logits: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+    """Per-token logit margin ``logit[true] - max_{j != true} logit[j]`` (>= 0 iff argmax is true).
+
+    ``pred_logits`` is the prediction window ``[batch, sequence, vocab]`` already aligned to
+    ``input_ids`` (position i predicts ``input_ids[:, i]``).
+    """
+    true_logit = pred_logits.gather(-1, input_ids.unsqueeze(-1)).squeeze(-1)  # [batch, sequence]
+    top2 = pred_logits.topk(2, dim=-1).values  # [batch, sequence, 2]
+    is_true_top1 = pred_logits.argmax(dim=-1) == input_ids
+    runner_up = torch.where(is_true_top1, top2[..., 1], top2[..., 0])
+    return true_logit - runner_up
+
+
+def budget_rebalance_loss_with_prefix(
+    logits: torch.Tensor,  # [batch, compression + prefix + sequence, vocab]
+    input_ids: torch.Tensor,  # [batch, sequence] (continuation, loss target)
+    attention_mask: torch.Tensor,  # [batch, sequence]
+    num_compression_tokens: int,
+    *,
+    base_ce_nats: torch.Tensor,  # [batch, sequence] cached H_base (nats), stage-constant
+    base_valid_mask: torch.Tensor,  # [batch, sequence] bool: positions with defined base surprisal
+    prefix_len: int = 0,
+    mode: str = "cap",
+    epsilon: float = 1.0,
+    reclaim_weight: float = 1.0,
+    water_level_bits: torch.Tensor | None = None,  # [batch] per-sample cap c = B / L (cap mode)
+    budget_bits: torch.Tensor | None = None,  # [batch] per-sample IG budget B (dual mode, + logging)
+    dual_lambda: torch.Tensor | None = None,  # [batch] per-sample Lagrange multiplier >= 0 (dual mode)
+    softcount_tau: float = 0.5,
+) -> tuple[torch.Tensor, dict]:
+    """Information-gain budget-rebalancing loss (paper Appendix, "budget rebalancing").
+
+    Redistributes the (roughly constant) per-sample information-gain budget so that MORE tokens
+    clear the fixed convergence margin ``epsilon``. Works on true per-token bits-saved
+    ``delta_bits_i = (H_base_i - H_comp_i) / ln2`` where ``H_comp_i`` is the per-token CE under the
+    memory embedding (differentiable) and ``H_base_i`` is the frozen-LM surprisal without it
+    (``base_ce_nats``, cached per stage since it does not depend on the embedding).
+
+    ``mode='cap'`` (C): a margin-deficit CE *floor* (identical mechanism to ``loss_margin``/+LM)
+    pushes tokens with ``margin < epsilon`` up, PLUS a *reclaim* term that pulls tokens with
+    ``margin > epsilon`` whose bits-saved exceed the adaptive water level ``water_level_bits`` back
+    down (``relu(delta_bits - c)``). The reclaim mask (``margin > epsilon``, detached) guarantees a
+    deficient token is never pushed further below the floor.
+
+    ``mode='dual'`` (D): maximize a soft count ``sigmoid((margin - epsilon)/tau)`` of tokens past
+    epsilon subject to a total-bits budget ``sum_i delta_bits_i <= budget_bits`` via the per-sample
+    Lagrangian ``-soft_count + lambda * (bits - B)`` (``lambda`` detached; the caller runs dual
+    ascent on the returned ``budget_violation``). KKT optimum is water-filling.
+
+    Returns ``(loss, diagnostics)``; ``diagnostics`` holds detached per-sample ``[batch]`` tensors
+    (``budget_violation``, ``total_bits``, ``min_margin``, ``margin_var``, ``delta_bits_max``,
+    ``delta_bits_cov``, ``soft_count``) for dual updates and the fungibility diagnostic.
+    """
+    if mode not in ("cap", "dual"):
+        raise ValueError(f"budget_rebalance mode must be 'cap' or 'dual', got {mode!r}!")
+    if num_compression_tokens < 1:
+        raise ValueError(f"num_compression_tokens must be >= 1, got {num_compression_tokens}!")
+
+    batch_size, seq_len = input_ids.shape
+    offset = num_compression_tokens + prefix_len
+    pred_logits = logits[:, offset - 1 : -1]  # [batch, sequence, vocab]
+    vocab = pred_logits.size(-1)
+
+    valid = (attention_mask == 1) & base_valid_mask.bool()  # [batch, sequence]
+    valid_f = valid.to(pred_logits.dtype)
+
+    comp_ce = F.cross_entropy(
+        pred_logits.reshape(-1, vocab),
+        input_ids.reshape(-1),
+        reduction="none",
+    ).view(
+        batch_size, seq_len
+    )  # per-token H_comp (nats), differentiable
+    margin = _per_token_margin(pred_logits, input_ids)  # [batch, sequence]
+    delta_bits = (base_ce_nats - comp_ce) / _LN2  # [batch, sequence]
+
+    with torch.no_grad():
+        vcount = valid_f.sum(dim=1).clamp_min(1.0)  # [batch]
+        m_mean = (margin * valid_f).sum(dim=1) / vcount
+        margin_var = (((margin - m_mean.unsqueeze(1)) ** 2) * valid_f).sum(dim=1) / vcount
+        min_margin = margin.masked_fill(~valid, float("inf")).amin(dim=1)
+        total_bits = (delta_bits * valid_f).sum(dim=1)  # [batch]
+        pos_delta = delta_bits.clamp_min(0.0) * valid_f
+        delta_max = pos_delta.amax(dim=1)  # [batch]
+        d_mean = pos_delta.sum(dim=1) / vcount
+        d_std = (((pos_delta - d_mean.unsqueeze(1)) ** 2) * valid_f).sum(dim=1).div(vcount).sqrt()
+        delta_cov = d_std / d_mean.clamp_min(1e-6)  # coefficient of variation (inequality proxy)
+
+    if mode == "cap":
+        if water_level_bits is None:
+            raise ValueError("water_level_bits is required for budget_rebalance mode='cap'!")
+        with torch.no_grad():
+            deficit_w = (epsilon - margin).clamp_min(0.0).masked_fill(~valid, 0.0)  # +LM floor weights
+            reclaim_mask = (valid & (margin > epsilon)).to(pred_logits.dtype)
+        floor = (comp_ce * deficit_w).sum() / deficit_w.sum().clamp_min(1e-6)
+        c = water_level_bits.to(delta_bits.dtype).view(batch_size, 1)  # [batch, 1]
+        excess = (delta_bits - c).clamp_min(0.0) * reclaim_mask  # differentiable through comp_ce
+        reclaim = excess.sum() / reclaim_mask.sum().clamp_min(1.0)
+        loss = floor + reclaim_weight * reclaim
+        soft_count = (margin > epsilon).to(pred_logits.dtype).mul(valid_f).sum(dim=1)
+        budget_violation = (total_bits - budget_bits) if budget_bits is not None else total_bits
+    else:  # dual
+        if budget_bits is None or dual_lambda is None:
+            raise ValueError("budget_bits and dual_lambda are required for budget_rebalance mode='dual'!")
+        soft = torch.sigmoid((margin - epsilon) / softcount_tau) * valid_f  # [batch, sequence]
+        soft_count = soft.sum(dim=1)  # [batch], differentiable
+        bits_per_sample = (delta_bits * valid_f).sum(dim=1)  # [batch], differentiable
+        violation = bits_per_sample - budget_bits.to(bits_per_sample.dtype)  # [batch]
+        lam = dual_lambda.to(bits_per_sample.dtype).clamp_min(0.0)  # detached (input is a buffer)
+        loss = (-soft_count + lam * violation).mean()
+        budget_violation = violation.detach()
+
+    diagnostics = {
+        "budget_violation": budget_violation.detach(),  # [batch]
+        "total_bits": total_bits,  # [batch]
+        "min_margin": min_margin,  # [batch]
+        "margin_var": margin_var,  # [batch]
+        "delta_bits_max": delta_max,  # [batch]
+        "delta_bits_cov": delta_cov,  # [batch]
+        "soft_count": soft_count.detach(),  # [batch]
+    }
+    return loss, diagnostics

--- a/src/compression_horizon/train/trainers/base.py
+++ b/src/compression_horizon/train/trainers/base.py
@@ -13,6 +13,7 @@ from torch.utils.tensorboard import SummaryWriter
 from compression_horizon.inference.generation import generate_from_compression
 from compression_horizon.train.embedding_init import create_compression_embedding, prepare_embedding_init
 from compression_horizon.train.loss import (
+    budget_rebalance_loss_with_prefix,
     compute_hybrid_cross_entropy_and_alignment_loss,
     token_argmax_match_rate_with_prefix,
 )
@@ -58,6 +59,9 @@ class BaseTrainer:
         log_dir = self.args.logging_dir
         self.writer = SummaryWriter(log_dir=log_dir) if log_dir and self.accelerator.is_main_process else None
         self.global_step = 0
+        # Per-sample diagnostics from the most recent budget-rebalancing loss (None when disabled);
+        # the progressive trainer reads these to run dual ascent and log the fungibility probe.
+        self._last_budget_diagnostics: dict | None = None
 
     def train(self) -> str | None:
         """Run training. Subclasses must override. Returns artifact path or output_dir or None."""
@@ -239,6 +243,7 @@ class BaseTrainer:
         num_compression_tokens: int,
         target_hidden_states: tuple[torch.Tensor, ...] | None = None,
         prefix_len: int = 0,
+        budget_ctx: dict | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, list[str] | None, list[str] | None]:
         """Forward + loss + convergence + diagnostics, returning a 5-tuple.
 
@@ -246,6 +251,13 @@ class BaseTrainer:
         tokens and the continuation in ``united_token_embeddings``; loss and convergence are then
         computed only over the continuation. ``input_ids``/``attention_mask``/``token_embeddings``
         describe the continuation only.
+
+        When ``args.budget_rebalance_mode`` is not ``"none"``, ``budget_ctx`` (built once per stage
+        by the progressive trainer) supplies the cached per-token base surprisal + adaptive
+        water-level / budget / dual multiplier, and the information-gain budget-rebalancing loss
+        replaces the plain CE/hybrid loss. The per-sample diagnostics it returns are stashed on
+        ``self._last_budget_diagnostics`` so the caller can run dual ascent and log the fungibility
+        probe without widening this return tuple.
         """
         # Compute vanilla model hidden states if alignment is required
         loss_type = self.args.loss_type.lower()
@@ -274,15 +286,39 @@ class BaseTrainer:
             attention_mask=united_attention_mask,
             **forward_extra_kwargs,
         )
-        loss, alignment_loss = self.compute_loss(
-            outputs.logits,
-            input_ids,
-            attention_mask,
-            num_compression_tokens,
-            compression_hidden_states=outputs.hidden_states,
-            target_hidden_states=target_hidden_states,
-            prefix_len=prefix_len,
-        )
+        budget_mode = str(getattr(self.args, "budget_rebalance_mode", "none") or "none")
+        if budget_mode != "none":
+            if budget_ctx is None:
+                raise ValueError("budget_rebalance_mode is set but no budget_ctx was supplied to forward_and_compute_loss!")
+            loss, budget_diagnostics = budget_rebalance_loss_with_prefix(
+                outputs.logits,
+                input_ids,
+                attention_mask,
+                num_compression_tokens,
+                base_ce_nats=budget_ctx["base_ce_nats"],
+                base_valid_mask=budget_ctx["base_valid_mask"],
+                prefix_len=prefix_len,
+                mode=budget_mode,
+                epsilon=float(getattr(self.args, "convergence_margin", 0.0) or 0.0),
+                reclaim_weight=float(getattr(self.args, "budget_rebalance_weight", 1.0)),
+                water_level_bits=budget_ctx.get("water_level_bits"),
+                budget_bits=budget_ctx.get("budget_bits"),
+                dual_lambda=budget_ctx.get("dual_lambda"),
+                softcount_tau=float(getattr(self.args, "budget_rebalance_softcount_tau", 0.5)),
+            )
+            alignment_loss = None
+            self._last_budget_diagnostics = budget_diagnostics
+        else:
+            loss, alignment_loss = self.compute_loss(
+                outputs.logits,
+                input_ids,
+                attention_mask,
+                num_compression_tokens,
+                compression_hidden_states=outputs.hidden_states,
+                target_hidden_states=target_hidden_states,
+                prefix_len=prefix_len,
+            )
+            self._last_budget_diagnostics = None
         convergence_per_sample = self.compute_convergence(
             outputs.logits, input_ids, attention_mask, num_compression_tokens, prefix_len=prefix_len
         )

--- a/src/compression_horizon/train/trainers/progressive_cramming.py
+++ b/src/compression_horizon/train/trainers/progressive_cramming.py
@@ -1,15 +1,18 @@
 """Progressive cramming trainer: progressively grow the target prefix until reconstruction fails."""
 
 import copy
+import math
 import os
 from dataclasses import dataclass, field
 
 import torch
+import torch.nn.functional as F
 from tqdm.auto import tqdm
 
 from compression_horizon.analysis import ProgressiveSampleStateMachine
 from compression_horizon.analysis.information_gain import (
     compute_information_gain,
+    compute_per_token_base_surprisal_nats,
     compute_prefix_surprisal_bits_per_token,
 )
 from compression_horizon.train.inputs import build_compression_attention_mask, build_united_input
@@ -820,9 +823,19 @@ class ProgressiveCrammingTrainer(BaseTrainer):
         scheduler_reset_used = False
         last_loss, last_convergence = None, None
 
+        # Cache the stage-constant H_base and snapshot the adaptive IG budget once per stage (the
+        # budget-rebalancing loss reuses these every step). None when rebalancing is disabled.
+        budget_ctx = self._prepare_budget_context(batch_ctx, stage_ctx, ctx)
+
         while True:
             last_loss, last_convergence, converged = self._run_steps(
-                batch_ctx, stage_ctx, ctx, state, retry=scheduler_reset_used, max_steps=max_steps_this_stage
+                batch_ctx,
+                stage_ctx,
+                ctx,
+                state,
+                retry=scheduler_reset_used,
+                max_steps=max_steps_this_stage,
+                budget_ctx=budget_ctx,
             )
             if converged:
                 return last_loss, last_convergence
@@ -831,6 +844,103 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             print(f"Not converged at seq_len={stage_ctx.seq_len}, resetting LR schedulers for non-converged samples...")
             self._reset_per_sample_optimizers(batch_ctx, ctx, state, max_steps_this_stage)
             scheduler_reset_used = True
+
+    @property
+    def _budget_rebalance_mode(self) -> str:
+        """Normalized ``args.budget_rebalance_mode`` ('none' | 'cap' | 'dual')."""
+        return str(getattr(self.args, "budget_rebalance_mode", "none") or "none")
+
+    @torch.no_grad()
+    def _prepare_budget_context(self, batch_ctx: _BatchContext, stage_ctx: _StageContext, ctx: _RunContext) -> dict | None:
+        """Cache H_base + snapshot the adaptive IG budget for the current stage (once per stage).
+
+        Returns a dict consumed by ``forward_and_compute_loss`` when budget rebalancing is on, or
+        ``None`` when it is off. ``base_ce_nats``/``base_valid_mask`` are the frozen-LM per-token
+        surprisal (embedding-independent, so a single forward per stage). ``budget_bits`` is the
+        per-sample information gain of the current (warm-started) embedding — the fixed budget we
+        redistribute — and ``water_level_bits = budget_bits / (#valid tokens)`` is the per-token
+        cap for 'cap' mode. ``dual_lambda`` is the per-sample multiplier for 'dual' mode (dual
+        ascent runs each step), reset to 0 at stage start.
+        """
+        if self._budget_rebalance_mode == "none":
+            return None
+        epsilon = float(getattr(self.args, "convergence_margin", 0.0) or 0.0)
+        if epsilon <= 0.0:
+            raise ValueError(
+                "budget_rebalance_mode requires convergence_margin > 0 (it is the epsilon the loss "
+                "rebalances tokens toward); set --convergence_margin."
+            )
+        base_ce_nats, base_valid_mask = compute_per_token_base_surprisal_nats(
+            model=ctx.decode_model,
+            input_ids=stage_ctx.input_ids,
+            attention_mask=stage_ctx.attention_mask,
+            prefix_token_embeddings=batch_ctx.prefix_token_embeddings,
+            prefix_attention_mask=batch_ctx.prefix_attention_mask,
+        )
+        comp_ce = self._forward_comp_ce(batch_ctx, stage_ctx, ctx)  # [batch, seq_len] nats
+        valid_f = base_valid_mask.to(comp_ce.dtype)
+        delta_bits = (base_ce_nats - comp_ce) / math.log(2.0)
+        budget_bits = (delta_bits * valid_f).sum(dim=1).clamp_min(1e-3)  # [batch] IG at stage start
+        vcount = valid_f.sum(dim=1).clamp_min(1.0)
+        water_level_bits = budget_bits / vcount
+        dual_lambda = torch.zeros(batch_ctx.batch_size, device=base_ce_nats.device, dtype=torch.float32)
+        return {
+            "base_ce_nats": base_ce_nats,
+            "base_valid_mask": base_valid_mask,
+            "budget_bits": budget_bits,
+            "water_level_bits": water_level_bits,
+            "dual_lambda": dual_lambda,
+        }
+
+    @torch.no_grad()
+    def _forward_comp_ce(self, batch_ctx: _BatchContext, stage_ctx: _StageContext, ctx: _RunContext) -> torch.Tensor:
+        """Per-token H_comp (nats) of the current live embedding, aligned to the continuation labels."""
+        embedding = batch_ctx.parametrization.materialize().clone()
+        united_token_embeddings, united_attention_mask = build_united_input(
+            embedding,
+            batch_ctx.compression_attention_mask,
+            stage_ctx.inputs_embeds,
+            stage_ctx.attention_mask,
+            prefix_token_embeddings=batch_ctx.prefix_token_embeddings,
+            prefix_attention_mask=batch_ctx.prefix_attention_mask,
+        )
+        logits = ctx.decode_model(inputs_embeds=united_token_embeddings, attention_mask=united_attention_mask).logits
+        offset = ctx.num_compression_tokens + batch_ctx.prefix_len
+        pred_logits = logits[:, offset - 1 : -1]
+        return F.cross_entropy(
+            pred_logits.reshape(-1, pred_logits.size(-1)),
+            stage_ctx.input_ids.reshape(-1),
+            reduction="none",
+        ).view_as(stage_ctx.input_ids)
+
+    def _update_and_log_budget(self, budget_ctx: dict) -> None:
+        """Dual ascent on the per-sample multiplier (dual mode) + TensorBoard fungibility diagnostics.
+
+        Reads ``self._last_budget_diagnostics`` (set by the just-completed budget-rebalancing
+        forward). ``lambda <- relu(lambda + dual_lr * (bits - B))`` tightens the budget constraint;
+        the logged margin-variance / min-margin / delta-bits inequality are the pre-registered
+        probe for whether the budget actually moved across tokens.
+        """
+        diag = self._last_budget_diagnostics
+        if diag is None:
+            return
+        if self._budget_rebalance_mode == "dual":
+            violation = diag["budget_violation"].to(budget_ctx["dual_lambda"].device)
+            dual_lr = float(getattr(self.args, "budget_rebalance_dual_lr", 0.05))
+            budget_ctx["dual_lambda"] = (budget_ctx["dual_lambda"] + dual_lr * violation).clamp_min(0.0)
+        if self.writer is None:
+            return
+        step = self.global_step
+        self.writer.add_scalar("budget/total_bits", diag["total_bits"].mean().item(), step)
+        self.writer.add_scalar("budget/margin_var", diag["margin_var"].mean().item(), step)
+        self.writer.add_scalar(
+            "budget/min_margin", torch.nan_to_num(diag["min_margin"], posinf=0.0, neginf=0.0).mean().item(), step
+        )
+        self.writer.add_scalar("budget/delta_bits_max", diag["delta_bits_max"].mean().item(), step)
+        self.writer.add_scalar("budget/delta_bits_cov", diag["delta_bits_cov"].mean().item(), step)
+        self.writer.add_scalar("budget/soft_count", diag["soft_count"].mean().item(), step)
+        if self._budget_rebalance_mode == "dual":
+            self.writer.add_scalar("budget/dual_lambda", budget_ctx["dual_lambda"].mean().item(), step)
 
     def _reset_per_sample_optimizers(
         self, batch_ctx: _BatchContext, ctx: _RunContext, state: ProgressiveSampleStateMachine, max_steps: int
@@ -858,6 +968,7 @@ class ProgressiveCrammingTrainer(BaseTrainer):
         state: ProgressiveSampleStateMachine,
         retry: bool,
         max_steps: int,
+        budget_ctx: dict | None = None,
     ):
         """Inner step loop within a stage. Returns (last_loss, last_convergence, converged_bool)."""
         progress_bar = tqdm(
@@ -898,6 +1009,7 @@ class ProgressiveCrammingTrainer(BaseTrainer):
                 ctx.num_compression_tokens,
                 target_hidden_states=stage_ctx.target_hidden_states,
                 prefix_len=batch_ctx.prefix_len,
+                budget_ctx=budget_ctx,
             )
             last_loss = float(loss.item())
             last_convergence = convergence_per_sample.detach().cpu()
@@ -930,6 +1042,9 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             self._step_per_sample_optimizers(batch_ctx, state)
             self._step_shared_optimizer(batch_ctx)
 
+            if budget_ctx is not None:
+                self._update_and_log_budget(budget_ctx)
+
             # Hard cap on cumulative per-sample steps across stages within this batch.
             # An exhausted sample is permanently skipped; if that drains the batch,
             # exit the stage as "converged" so the outer retry path doesn't fire
@@ -937,17 +1052,19 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             # just stepped, so re-measure the live embedding to keep the returned metrics
             # consistent with the embedding ``_collect_stage_rows`` will save.
             if state.mark_exhausted(self.args.max_optimization_steps_per_sample):
-                last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx)
+                last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx, budget_ctx)
                 return last_loss, last_convergence, True
 
         # Max steps for this stage reached without all samples converging. The optimizer
         # stepped on the final iteration, so re-measure the live (post-step) embedding to
         # keep the returned metrics consistent with what ``_collect_stage_rows`` saves.
-        last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx)
+        last_loss, last_convergence = self._measure_live(batch_ctx, stage_ctx, ctx, budget_ctx)
         return last_loss, last_convergence, False
 
     @torch.no_grad()
-    def _measure_live(self, batch_ctx: "_BatchContext", stage_ctx: "_StageContext", ctx: "_RunContext"):
+    def _measure_live(
+        self, batch_ctx: "_BatchContext", stage_ctx: "_StageContext", ctx: "_RunContext", budget_ctx: dict | None = None
+    ):
         """Forward the current live embedding; return ``(loss, convergence_per_sample_cpu)``.
 
         Used only on non-converged stage exits (per-sample budget exhausted, or max steps
@@ -975,6 +1092,7 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             ctx.num_compression_tokens,
             target_hidden_states=stage_ctx.target_hidden_states,
             prefix_len=batch_ctx.prefix_len,
+            budget_ctx=budget_ctx,
         )
         return float(loss.item()), convergence_per_sample.detach().cpu()
 
@@ -1174,6 +1292,7 @@ class ProgressiveCrammingTrainer(BaseTrainer):
             "num_compression_tokens": int(ctx.num_compression_tokens),
             "hidden_size": int(comp_tokens_cpu.shape[-1]),
             "loss_type": self.args.loss_type,
+            "budget_rebalance_mode": str(getattr(self.args, "budget_rebalance_mode", "none") or "none"),
             "dtype": self.args.dtype,
             "model_checkpoint": self.args.model_checkpoint,
             "max_optimization_steps_per_sample": int(self.args.max_optimization_steps_per_sample),

--- a/tests/test_budget_rebalance_loss.py
+++ b/tests/test_budget_rebalance_loss.py
@@ -1,0 +1,159 @@
+"""Unit tests for the information-gain budget-rebalancing loss.
+
+The loss (``budget_rebalance_loss_with_prefix``) consumes logits + a cached per-token base
+surprisal directly, so its mechanism is testable on synthetic tensors with no model. We assert the
+two defining gradient signs:
+
+* **floor** (margin < epsilon): pushes the true-token logit UP (reduces CE) -> grad is negative.
+* **reclaim** (margin > epsilon and delta_bits > water level): pulls the true-token logit DOWN
+  (reduces bits-saved, reclaiming budget) -> grad is positive. This is the behaviour +LM lacks.
+
+A separate test covers the cached ``compute_per_token_base_surprisal_nats`` helper (shape + the
+no-prefix token-0 invalid mask) with a tiny CPU GPT2.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from compression_horizon.analysis.information_gain import compute_per_token_base_surprisal_nats
+from compression_horizon.train.loss import budget_rebalance_loss_with_prefix
+
+_LN2 = math.log(2.0)
+
+
+def _build_synthetic_logits() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One sample, 3 continuation tokens (true id = 0), num_compression_tokens = 1, no prefix.
+
+    Token 0: margin 5.0 (>> epsilon) with a large bits-saving -> reclaim candidate.
+    Token 1: margin 0.2 (<  epsilon)                          -> floor candidate.
+    Token 2: margin ~1.0 (== epsilon)                          -> neither.
+    """
+    # logits length = num_compression_tokens (1) + sequence (3) = 4; pred window = logits[:, 0:3].
+    logits = torch.zeros(1, 4, 4)
+    logits[0, 0, 0] = 5.0  # token 0 true logit (big margin)
+    logits[0, 1, 0] = 0.2  # token 1 true logit (deficient)
+    logits[0, 2, 0] = 1.0  # token 2 true logit (~epsilon)
+    logits[0, 3, 0] = 0.0  # unused trailing position
+    logits = logits.clone().requires_grad_(True)
+    input_ids = torch.zeros(1, 3, dtype=torch.long)
+    attention_mask = torch.ones(1, 3, dtype=torch.long)
+    return logits, input_ids, attention_mask
+
+
+def test_cap_mode_gradient_signs():
+    """Reclaim pushes an over-budget token's true logit down; floor pushes a deficient one up."""
+    logits, input_ids, attention_mask = _build_synthetic_logits()
+    base_ce_nats = torch.full((1, 3), 3.0)  # generous base surprisal -> positive bits-saved
+    base_valid_mask = torch.ones(1, 3, dtype=torch.bool)
+
+    loss, diag = budget_rebalance_loss_with_prefix(
+        logits,
+        input_ids,
+        attention_mask,
+        num_compression_tokens=1,
+        base_ce_nats=base_ce_nats,
+        base_valid_mask=base_valid_mask,
+        prefix_len=0,
+        mode="cap",
+        epsilon=1.0,
+        reclaim_weight=1.0,
+        water_level_bits=torch.tensor([1.0]),  # cap each token at 1 bit
+        budget_bits=torch.tensor([3.0]),
+    )
+    assert torch.isfinite(loss)
+    loss.backward()
+
+    # Token 0 is over-margined AND over-budget -> reclaim raises loss with its true logit -> grad > 0.
+    assert logits.grad[0, 0, 0].item() > 0.0
+    # Token 1 is deficient -> floor lowers loss by raising its true logit -> grad < 0.
+    assert logits.grad[0, 1, 0].item() < 0.0
+    # Diagnostics are per-sample [batch] tensors.
+    assert diag["total_bits"].shape == (1,)
+    assert diag["min_margin"].shape == (1,)
+
+
+def test_cap_reclaim_disabled_when_below_water_level():
+    """A high water level (no token exceeds it) => no reclaim => only the floor term contributes."""
+    logits, input_ids, attention_mask = _build_synthetic_logits()
+    base_ce_nats = torch.full((1, 3), 3.0)
+    base_valid_mask = torch.ones(1, 3, dtype=torch.bool)
+
+    loss, _ = budget_rebalance_loss_with_prefix(
+        logits,
+        input_ids,
+        attention_mask,
+        num_compression_tokens=1,
+        base_ce_nats=base_ce_nats,
+        base_valid_mask=base_valid_mask,
+        mode="cap",
+        epsilon=1.0,
+        reclaim_weight=1.0,
+        water_level_bits=torch.tensor([100.0]),  # unreachable cap
+        budget_bits=torch.tensor([3.0]),
+    )
+    loss.backward()
+    # With reclaim inert, the over-margined token 0 gets no gradient (floor weight is 0 there too).
+    assert abs(logits.grad[0, 0, 0].item()) < 1e-6
+    # The deficient token 1 still receives the floor's upward push.
+    assert logits.grad[0, 1, 0].item() < 0.0
+
+
+def test_dual_mode_runs_and_reports_violation():
+    """Dual mode returns a finite loss and a budget violation equal to total_bits - budget."""
+    logits, input_ids, attention_mask = _build_synthetic_logits()
+    base_ce_nats = torch.full((1, 3), 3.0)
+    base_valid_mask = torch.ones(1, 3, dtype=torch.bool)
+    budget = torch.tensor([1.0])
+
+    loss, diag = budget_rebalance_loss_with_prefix(
+        logits,
+        input_ids,
+        attention_mask,
+        num_compression_tokens=1,
+        base_ce_nats=base_ce_nats,
+        base_valid_mask=base_valid_mask,
+        mode="dual",
+        epsilon=1.0,
+        budget_bits=budget,
+        dual_lambda=torch.tensor([0.5]),
+        softcount_tau=0.5,
+    )
+    assert torch.isfinite(loss)
+    loss.backward()  # soft-count + budget terms are both differentiable
+    assert logits.grad is not None
+    # budget_violation == total_bits - budget (both per-sample).
+    assert torch.allclose(diag["budget_violation"], diag["total_bits"] - budget, atol=1e-5)
+    # soft_count in [0, sequence_len].
+    assert 0.0 <= diag["soft_count"].item() <= 3.0
+
+
+def test_base_surprisal_helper_no_prefix_masks_first_token():
+    """Cached H_base: correct shape, token 0 invalid without a prefix, matches manual CE elsewhere."""
+    torch.manual_seed(0)
+    config = GPT2Config(vocab_size=50, n_positions=32, n_embd=16, n_layer=2, n_head=2)
+    model = GPT2LMHeadModel(config).eval()
+
+    input_ids = torch.randint(0, 50, (2, 5))
+    attention_mask = torch.ones(2, 5, dtype=torch.long)
+
+    base_ce, valid = compute_per_token_base_surprisal_nats(model=model, input_ids=input_ids, attention_mask=attention_mask)
+    assert base_ce.shape == (2, 5)
+    assert valid.shape == (2, 5)
+    # No prefix => token 0 has no predictor and is masked out.
+    assert not valid[:, 0].any()
+    assert valid[:, 1:].all()
+
+    # Position i (>=1) should equal the plain LM next-token CE from logits[i-1].
+    with torch.no_grad():
+        logits = model(input_ids=input_ids, attention_mask=attention_mask).logits
+    manual = F.cross_entropy(
+        logits[:, :-1, :].reshape(-1, logits.size(-1)),
+        input_ids[:, 1:].reshape(-1),
+        reduction="none",
+    ).view(2, 4)
+    assert torch.allclose(base_ce[:, 1:], manual, atol=1e-4)

--- a/tests/test_progressive_cramming_trainer.py
+++ b/tests/test_progressive_cramming_trainer.py
@@ -48,6 +48,49 @@ def test_progressive_cramming_trainer_smoke():
     assert out is None or isinstance(out, str)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("mode", ["cap", "dual"])
+def test_progressive_cramming_budget_rebalance_smoke(mode):
+    """Run train() with budget rebalancing on (cap/dual): exercises H_base caching + budget_ctx + dual."""
+    model = AutoModelForCausalLM.from_pretrained("HuggingFaceTB/SmolLM2-135M", torch_dtype=torch.bfloat16)
+    model.to("cuda")
+    tokenizer = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-135M")
+
+    args = _make_args(
+        progressive_train=True,
+        progressive_min_seq_len=2,
+        progressive_step=1,
+        progressive_max_stages=2,
+        max_optimization_steps_per_sample=2,
+        max_optimization_steps_per_token=2,
+        number_of_mem_tokens=1,
+        logging_dir=None,
+        convergence_margin=1.0,  # epsilon the rebalancer targets (required > 0)
+        budget_rebalance_mode=mode,
+        budget_rebalance_weight=1.0,
+    )
+    dataset = TinyDataset(num_samples=2, seq_len=8, vocab_size=16)
+
+    trainer = ProgressiveCrammingTrainer(
+        model=model,
+        processing_class=tokenizer,
+        args=args,
+        train_dataset=dataset,
+        eval_dataset=None,
+        data_collator=_collate_batch,
+    )
+    out = trainer.train()
+    assert out is None or isinstance(out, str)
+
+
+def test_budget_rebalance_requires_positive_margin():
+    """_prepare_budget_context raises if convergence_margin <= 0 (epsilon is undefined)."""
+    args = _make_args(budget_rebalance_mode="cap", convergence_margin=0.0)
+    trainer = _blank_trainer(args)
+    with pytest.raises(ValueError, match="convergence_margin"):
+        trainer._prepare_budget_context(SimpleNamespace(), SimpleNamespace(), SimpleNamespace())
+
+
 def _blank_trainer(args):
     """A ProgressiveCrammingTrainer without running __init__ (we only exercise pure methods)."""
     trainer = ProgressiveCrammingTrainer.__new__(ProgressiveCrammingTrainer)


### PR DESCRIPTION
…essive cramming

Adds a budget-rebalancing loss that reclaims IG budget from over-margined tokens so more tokens clear a fixed convergence margin epsilon than plain-CE / +LM (which only raise the floor, never reclaim). Two arms, both on true bits-saved delta_bits = (H_base - H_comp)/ln2 with H_base cached per stage (embedding-independent):
  - cap (C):  margin-deficit CE floor + reclaim term pulling over-budget tokens down to an adaptive water level c = B/L.
  - dual (D): maximize a soft count of tokens past epsilon s.t. Sum delta_bits <= B via a per-sample dual variable (dual ascent); KKT optimum is water-filling.

- loss.py: budget_rebalance_loss_with_prefix + _per_token_margin, diagnostics.
- information_gain.py: compute_per_token_base_surprisal_nats (cached H_base, valid mask).
- arguments.py: budget_rebalance_mode/weight/dual_lr/softcount_tau.
- trainers/base.py + progressive_cramming.py: per-stage H_base + IG-budget snapshot, budget_ctx threading, per-sample dual ascent, budget/* TensorBoard diagnostics.
- run_jobs_progressive.py: 12 Pythia-1.4B arms (baseline+lowdim x eps{0.5,1,2} x {cap,dual}).
- tests: unit (gradient signs, base surprisal) + cap/dual integration smoke; default mode="none" path unchanged (30 progressive/IG tests still pass).

Plan: experiments/budget_rebalancing.md; design/rationale in ADRs 0004/0005 + CONTEXT.md.